### PR TITLE
enable parallel testing

### DIFF
--- a/commander.go
+++ b/commander.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// commander keeps track of a directory and runs commands on them providing
+// a crude form of parallelism.
+type commander struct {
+	*sync.Mutex
+	path string
+	// checkin is a buffered channel. It's length limits the amount of goroutines running commands at once.
+	checkin chan struct{}
+}
+
+func newCommander() commander {
+	path, err := os.Getwd()
+	if err != nil {
+		log.Fatal("getting current dir:", err)
+	}
+	goroutines := runtime.NumCPU() / 2
+	if goroutines == 0 {
+		goroutines = 1
+	}
+	log.Println("setting max simultaneous commands to", goroutines)
+	return commander{
+		path:    path,
+		checkin: make(chan struct{}, goroutines),
+		Mutex:   &sync.Mutex{},
+	}
+}
+
+func (c *commander) cloneOrUpdateRepo(repo string) {
+	if _, err := c.Stat(repo); err != nil {
+		// Repo does not exist.
+		log.Printf("repo not found. cloning %s", repo)
+		d := filepath.Dir(repo)
+		if _, err := c.Stat(repo); err != nil {
+			log.Printf("creating directory %s", d)
+			c.Mkdir(d, dirMode)
+		}
+		c.Chdir(d)
+		c.run(false, "git", "clone", fmt.Sprintf("%s/%s", hostURL, repo))
+		return
+	}
+
+	c.Chdir(repo)
+	log.Printf("repo exists, updating %s", repo)
+	c.run(false, "git", "fetch")
+	c.run(false, "git", "pull")
+}
+
+func (r commander) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(r.join(path))
+}
+func (r commander) Mkdir(d string, mode fs.FileMode) error {
+	return os.MkdirAll(r.join(d), mode)
+}
+func (r *commander) Chdir(path string) {
+	r.path = r.join(path)
+}
+func (r commander) join(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(r.path, path)
+}
+
+func (r *commander) run(async bool, name string, arg ...string) {
+	r.checkin <- struct{}{} // Check-in for work.
+	cmd := exec.Command(name, arg...)
+	r.Lock() // protect Chdir and cmd.Start
+	defer r.Unlock()
+	path := r.path
+	err := os.Chdir(path)
+	cwd, _ := os.Getwd()
+	if err != nil {
+		log.Fatal("os.Chdir error: ", err)
+	}
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	cmd.Stderr = &b
+	err = cmd.Start()
+	if err != nil {
+		log.Fatalf("%s\ncmd %s with err: %q at dir %q", b.String(), cmd.String(), err, cwd)
+	}
+
+	err = os.Chdir(r.path)
+	if err != nil {
+		log.Fatalf("changing directory to %s, from %s: %s", r.path, path, err)
+	}
+	done := make(chan struct{})
+	go func() {
+		if async {
+			done <- struct{}{}
+		}
+		err = cmd.Wait()
+		if err != nil {
+			log.Fatalf("%s\ncmd %s with err: %v at dir %q", b.String(), cmd.String(), err, path)
+		}
+		log.Printf("cmd %s finished with output:\n%s", cmd, b.String())
+		<-r.checkin // Check-out
+		if !async {
+			done <- struct{}{}
+		}
+	}()
+	<-done
+}

--- a/main.go
+++ b/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -23,6 +22,8 @@ const (
 func main() {
 	configYaml := flag.String("config", "repos.yaml", "yaml of repositories to run")
 	compiler := flag.String("compiler", "tinygo", "use this go compiler")
+	runPattern := flag.String("run", "", "compiler will run on all repo names matching this pattern (regexp)")
+	parallelism := flag.Int("parallel", 2, "max number of goroutines running compiler at any time")
 
 	flag.Parse()
 
@@ -36,38 +37,38 @@ func main() {
 		log.Printf("Finished!\n%d/%d repos tested\n%d passed subdir tests\n", countRepo, len(repos), countSubdir)
 	}()
 
-	// Workspace setup and cleanup.
-	baseDir, err := os.Getwd()
+	// Which repos to run.
+	re, err := regexp.Compile(*runPattern)
 	if err != nil {
-		log.Fatal("getting current dir:", err)
+		log.Fatal("compiling run regexp:", err)
 	}
 
-	corpusDir := filepath.Join(baseDir, corpusFolderName)
-	if strings.HasSuffix(*compiler, "tinygo") {
-		mustrun(*compiler, "clean")
-	}
-	if err != nil {
-		log.Fatalf("calling `%v clean`: %s", *compiler, err)
-	}
-	os.Mkdir(corpusDir, dirMode) // force directory creation if not exist.
-	_, err = os.ReadDir(corpusDir)
+	// Workspace setup and cleanup.
+	goos := newCommander(*parallelism)
+	goos.Run(*compiler, "clean")
+
+	goos.Mkdir(corpusFolderName, dirMode) // force directory creation if not exist.
+	_, err = goos.Stat(corpusFolderName)
 	if err != nil {
 		log.Fatal("reading corpus directory: ", err)
 	}
+	goos.Chdir(corpusFolderName)
+	corpusDir := goos.path
 
 	// Commence testing logic. Start from latest repo additions (end of repos).
-	oos := newCommander()
-	for i := len(repos) - 1; i >= 0; i-- {
-		repo := repos[i]
-		oos.Chdir(corpusDir)
-		oos.cloneOrUpdateRepo(repo.Repo)
+	for _, repo := range repos {
+		if !re.MatchString(repo.Repo) {
+			continue
+		}
+		goos.Chdir(corpusDir)
+		goos.cloneOrUpdateRepo(repo.Repo)
 		repoBase := filepath.Join(corpusDir, repo.Repo)
-		oos.Chdir(repoBase)
+		goos.Chdir(repoBase)
 
-		if _, err := oos.Stat("go.mod"); err != nil {
+		if _, err := goos.Stat("go.mod"); err != nil {
 			log.Printf("creating %s/go.mod: running `go mod init`\n", repoBase)
-			oos.run(false, "go", "mod", "init", fmt.Sprintf("%s/%s", host, repo.Repo))
-			oos.run(false, "go", "get", "-t", ".")
+			goos.Run("go", "mod", "init", fmt.Sprintf("%s/%s", host, repo.Repo))
+			goos.Run("go", "get", "-t", ".")
 		}
 		tags := ""
 		if repo.Tags != "" {
@@ -80,26 +81,17 @@ func main() {
 
 		for _, subdir := range dirs {
 			if subdir != "." {
-				oos.Chdir(subdir)
+				goos.Chdir(subdir)
 			}
-			oos.run(true, *compiler, "test", "-v", "-tags="+tags)
+			goos.Start(*compiler, "test", "-v", "-tags="+tags)
+			countSubdir++
 			if subdir != "." {
-				oos.Chdir(repoBase)
+				goos.Chdir(repoBase)
 			}
 		}
 		countRepo++
 		log.Printf("finished module %d/%d %s", countRepo, len(repos), repo.Repo)
 	}
-}
-
-func mustrun(name string, arg ...string) (stdout string) {
-	cmd := exec.Command(name, arg...)
-	b, err := cmd.CombinedOutput()
-	if err != nil {
-		cwd, _ := os.Getwd()
-		log.Fatalf("%s\ncmd %s with err: %q at dir %q", string(b), cmd.String(), err, cwd)
-	}
-	return string(b)
 }
 
 type T struct {

--- a/repos.yaml
+++ b/repos.yaml
@@ -126,7 +126,7 @@
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
-  - encoding/utf32
+  - encoding/unicode/utf32
   - internal/format
   - internal/ucd
   - internal/tag


### PR DESCRIPTION
PTAL. I've created a directory context handler `commander` which enables running `tinygo test` commands in parallel with others. This could be further streamlined adding a "repoReady" channel to which cloneOrUpdateRepo sends repos that are ready to test.