### PR TITLE
bugfix: forgot to wait for parallel tasks at program end

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,6 +92,8 @@ func main() {
 		countRepo++
 		log.Printf("finished module %d/%d %s", countRepo, len(repos), repo.Repo)
 	}
+	goos.Wait()
+
 }
 
 type T struct {


### PR DESCRIPTION
_whoops_
Steps to replicate bug:
```shell
go run . -parallel 12 -run bloom
```
output:
```
2021/12/04 19:12:15 setting max simultaneous commands to 12
2021/12/04 19:12:15 cmd /home/pato/local/bin/tinygo clean finished with output:
2021/12/04 19:12:15 repo exists, updating dgryski/go-bloomindex
2021/12/04 19:12:17 cmd /usr/bin/git fetch finished with output:
2021/12/04 19:12:19 cmd /usr/bin/git pull finished with output:
Already up to date.
2021/12/04 19:12:19 finished module 1/75 dgryski/go-bloomindex
2021/12/04 19:12:19 Finished!
1/75 repos tested
1 passed subdir tests
```

Expected output:
```
2021/12/04 19:12:34 setting max simultaneous commands to 12
2021/12/04 19:12:34 cmd /home/pato/local/bin/tinygo clean finished with output:
2021/12/04 19:12:34 repo exists, updating dgryski/go-bloomindex
2021/12/04 19:12:36 cmd /usr/bin/git fetch finished with output:
2021/12/04 19:12:38 cmd /usr/bin/git pull finished with output:
Already up to date.
2021/12/04 19:12:38 finished module 1/75 dgryski/go-bloomindex
2021/12/04 19:12:49 cmd /home/pato/local/bin/tinygo test -v -tags=purego noasm finished with output:
=== RUN   TestBlockGetSet
--- PASS: TestBlockGetSet
=== RUN   TestBlockQuery
--- PASS: TestBlockQuery
=== RUN   TestEndToEnd
--- PASS: TestEndToEnd
=== RUN   TestShardEndToEnd
--- PASS: TestShardEndToEnd
=== RUN   TestPopset
--- PASS: TestPopset
PASS
ok  	github.com/dgryski/go-bloomindex	0.020s
2021/12/04 19:12:50 Finished!
1/75 repos tested
1 passed subdir tests
```